### PR TITLE
Added Favicon to website

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,5 +12,11 @@ module.exports = {
         head: true,
       },
     },
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        icon: `src/assets/opf-logo.png`
+      },
+    },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mantine/hooks": "^4.2.2",
         "gatsby": "^4.13.1",
         "gatsby-plugin-google-analytics": "^4.14.0",
+        "gatsby-plugin-manifest": "^4.14.0",
         "gatsby-plugin-mantine": "^4.0.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -10155,6 +10156,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/gatsby-plugin-manifest": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.14.0.tgz",
+      "integrity": "sha512-vwN5ZasR6/I9Xd1Ar3+UhMaYN6EU7PJhJKY6aQMAtG1Qxva5lDjmrWNzUlm8NHL/XmB4VSS+A4TZUZHyoygZ7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "gatsby-core-utils": "^3.14.0",
+        "gatsby-plugin-utils": "^3.8.0",
+        "semver": "^7.3.7",
+        "sharp": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
       }
     },
     "node_modules/gatsby-plugin-mantine": {
@@ -26436,6 +26455,18 @@
             "brace-expansion": "^1.1.7"
           }
         }
+      }
+    },
+    "gatsby-plugin-manifest": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.14.0.tgz",
+      "integrity": "sha512-vwN5ZasR6/I9Xd1Ar3+UhMaYN6EU7PJhJKY6aQMAtG1Qxva5lDjmrWNzUlm8NHL/XmB4VSS+A4TZUZHyoygZ7Q==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "gatsby-core-utils": "^3.14.0",
+        "gatsby-plugin-utils": "^3.8.0",
+        "semver": "^7.3.7",
+        "sharp": "^0.30.3"
       }
     },
     "gatsby-plugin-mantine": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mantine/hooks": "^4.2.2",
     "gatsby": "^4.13.1",
     "gatsby-plugin-google-analytics": "^4.14.0",
+    "gatsby-plugin-manifest": "^4.14.0",
     "gatsby-plugin-mantine": "^4.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",


### PR DESCRIPTION
## Description
This commit adds our new logo as the favicon to our website's browser's tabs. This commit was made from feedback given from the Red Hat research meeting this morning.

Changes:
- Added `gatsby-plugin-manifest` plugin

## Preview
![image](https://user-images.githubusercontent.com/68972382/168876031-0afd4d90-9854-443f-b6c7-10b3a2cd6a7b.png)
