### PR TITLE
replace op1st by Our

### DIFF
--- a/src/components/homepage/Navbar.js
+++ b/src/components/homepage/Navbar.js
@@ -98,7 +98,7 @@ export function Nav({ links }) {
     },
     {
       "link": "/community-cloud",
-      "label": "Op1st Community Cloud"
+      "label": "Our Community Cloud"
     }
   ];
   if (!links) {


### PR DESCRIPTION
As discussed in our WG website update meeting on 2022-05-31
1. op1st as shorthand is still in discussion
2. the logo and all says operate first, so it doesn't need to be doubled
3. but as there is already a "Community" in the navbar, we decided to add a "separator" and go with "Our" by now
  3.1. maybe looking for a better general word for Community Cloud or another shorthand then
  3.2. and also stay consistent with the our in "Our Purpose"

replace op1st by Our to avoid op1st but still separate the two menu items with "Community"

@quaid @bryanmontalvan @stefwrite @aakankshaduggal 