### PR TITLE
Linking to Getting Started from all over

### DIFF
--- a/src/components/nav-tabs/AboutPage.js
+++ b/src/components/nav-tabs/AboutPage.js
@@ -85,6 +85,9 @@ export function AboutContent() {
             </Text>
             <hr />
             <Title order={4} my="md">Where to start:</Title>
+            <Text py="md">
+              <a href="/getting-started"><b>Jump to Getting Started page</b></a>
+            </Text>
             <Text>
               Continue learning more about Operate First: <a href="https://www.operate-first.cloud/training/operate_first_intro" target="_blank" rel="noreferrer">Introduction to Operate First</a>
             </Text>

--- a/src/components/nav-tabs/CommunityPage.js
+++ b/src/components/nav-tabs/CommunityPage.js
@@ -89,6 +89,9 @@ export function CommunityContent() {
                   methods and practices of running a cloud</b>.
                 </Text>
                 <Title pt="md" order={2}>Join us!</Title>
+                <Text py="md">
+                  <a href="/getting-started"><b>Jump to Getting Started page</b></a>
+                </Text>
                 <Text py="sm">
                     Find our code on <a href="https://github.com/operate-first/apps">GitHub</a>, meet the community on Slack, and <a href="https://lists.operate-first.cloud/">join our mailing lists</a> for announcements and discussions:
                 </Text>

--- a/src/components/nav-tabs/DocTraining.js
+++ b/src/components/nav-tabs/DocTraining.js
@@ -7,6 +7,10 @@ export function DocTrainingContent() {
         <Container pb={350}>
             <Title order={2} my="md">Operate First Documentation and Training</Title>
 
+            <Text py="md">
+              <a href="/getting-started"><b>Jump to Getting Started page</b></a>
+            </Text>
+
             <Text py="sm">
               <b>GitOps, cloud native, managed service, Open Source</b>, and so
               many other concepts

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -82,6 +82,9 @@ const CommunityCloudPage = () => {
                 <Text>
                     It&apos;s operated under a community SLA and as open and transparent as possible.
                 </Text>
+                <Text py="md">
+                  <a href="/getting-started"><b>Click here to get started as a user and contributor</b></a>
+                </Text>
 
                 <Title order={2} my="lg">Resources</Title>
 


### PR DESCRIPTION
- As the default call-to-action (CTA) page, this one is linked from
  various information pages, including and especially all of the
  pages in the top menu
- This now has a link in an appropriate place on the page for every
  menu item landing page

Signed-off-by: Karsten Wade <kwade@redhat.com>