### PR TITLE
Fixed service catalog mobile responsiveness

### DIFF
--- a/src/components/nav-tabs/Services.js
+++ b/src/components/nav-tabs/Services.js
@@ -71,7 +71,14 @@ const ServicesBoard = () => {
             <Container pb={69} style={{ paddingLeft: 0, paddingRight: 0 }}>
                 <Title order={2} my="md">Our Services</Title>
                 <Card withBorder radius="md" className={classes.card}>
-                    <SimpleGrid cols={3} mt="md">
+                    <SimpleGrid
+                        cols={3}
+                        mt="md"
+                        breakpoints={[
+                            { maxWidth: 980, cols: 2, spacing: 'md' },
+                            { maxWidth: 600, cols: 1, spacing: 'sm' },
+                        ]}
+                    >
                         {items}
                     </SimpleGrid>
                 </Card>

--- a/src/pages/community-cloud-workloads.js
+++ b/src/pages/community-cloud-workloads.js
@@ -2,26 +2,45 @@ import * as React from "react";
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
-import { Container, Title} from '@mantine/core';
+import { Container, Title, createStyles, } from '@mantine/core';
 
+const grafanaLinks = [
+    {
+        name: "smaug",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/smaug&var-namespace=All&theme=light&panelId=4"
+    },
+    {
+        name: "infra",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/infra&var-namespace=All&theme=light&panelId=4",
+    },
+    {
+        name: "balrog",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=emea/balrog&var-namespace=All&theme=light&panelId=4"
+    }
+]
+
+const useStyles = createStyles(() => ({
+    frame: {
+        width: '100%',
+        height: 400,
+        border: 'none',
+    }
+}));
 const CommunityCloudPage = () => {
+    const { classes } = useStyles();
 
     return (
         <main>
-        <Nav/>
-        <Container>
-        <Title order={2} my="md">Op1st Community Cloud</Title>
-
-        <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/smaug&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
-
-        <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/infra&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
-
-        <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=emea/balrog&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
-        </Container>
-        <Footer/>
+            <Nav />
+            <Container>
+                <Title order={2} my="md">Op1st Community Cloud</Title>
+                <iframe src={grafanaLinks[0].link} className={classes.frame}></iframe>
+                <iframe src={grafanaLinks[1].link} className={classes.frame}></iframe>
+                <iframe src={grafanaLinks[2].link} className={classes.frame}></iframe>
+            </Container>
+            <Footer />
         </main>
-
-        );
-    }
+    );
+}
 
 export default CommunityCloudPage;

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -15,7 +15,6 @@ import {
     Card,
     SimpleGrid,
     UnstyledButton,
-    Anchor
 } from '@mantine/core';
 import { Book, Cloud } from 'tabler-icons-react';
 
@@ -26,6 +25,21 @@ const clusters = [
     { title: 'Rick', icon: Cloud, color: 'blue', url: 'https://console-openshift-console.apps.rick.emea.operate-first.cloud/', },
     { title: 'Balrog', icon: Cloud, color: 'orange', url: 'https://console-openshift-console.apps.balrog.aws.operate-first.cloud/', },
 ];
+
+const grafanaLinks = [
+    {
+        name: "smaug",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/smaug&var-namespace=All&theme=light&panelId=4"
+    },
+    {
+        name: "infra",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/infra&var-namespace=All&theme=light&panelId=4",
+    },
+    {
+        name: "balrog",
+        link: "https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=emea/balrog&var-namespace=All&theme=light&panelId=4"
+    }
+]
 
 const useStyles = createStyles((theme) => ({
     card: {
@@ -53,10 +67,13 @@ const useStyles = createStyles((theme) => ({
             transform: 'scale(1.05)',
         },
     },
+
+    frame: {
+        width: '100%',
+        height: 400,
+        border: 'none',
+    }
 }));
-
-
-
 
 const CommunityCloudPage = () => {
     const { classes, theme } = useStyles();
@@ -100,12 +117,6 @@ const CommunityCloudPage = () => {
                 <Title order={2} my="md">Clusters</Title>
 
                 <Card withBorder radius="md" className={classes.card}>
-                    <Group position="apart">
-                        <Text className={classes.title}>Services</Text>
-                        <Anchor size="xs" color="dimmed" sx={{ lineHeight: 1 }}>
-                            ...
-                        </Anchor>
-                    </Group>
                     <SimpleGrid cols={3} mt="md">
                         {items}
                     </SimpleGrid>
@@ -114,9 +125,9 @@ const CommunityCloudPage = () => {
                 <ServicesBoard />
 
                 <Title order={2} my="md">Workloads</Title>
-                <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/smaug&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
-                <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/infra&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
-                <iframe src="https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=emea/balrog&var-namespace=All&theme=light&panelId=4" width="1200" height="400" frameBorder="0"></iframe>
+                <iframe src={grafanaLinks[0].link} className={classes.frame}></iframe>
+                <iframe src={grafanaLinks[1].link} className={classes.frame}></iframe>
+                <iframe src={grafanaLinks[2].link} className={classes.frame}></iframe>
             </Container>
             <Footer />
         </main>


### PR DESCRIPTION
## Description
This commit adds breakpoints to the `SimpleGrid` component so that all the services cards can be viewable and spaced properly on mobile devices. Also the `iframe`'s themselves's width fits within the device's resolution

This commit also adds changes to the composition of the cards themselves in order to promote more readability to the iframe objects themselves.
- Created grafanaLinks object and created a style class for the iFrames.

Misc:
- Removed unused anchor import
## Issue(s)
Resolves #74

## Previews 
![image](https://user-images.githubusercontent.com/68972382/172676420-c1587049-441f-48aa-b111-26dabf5e48dc.png)
