### PR TITLE
Removed nav menu items bug on docs & train

### DIFF
--- a/src/components/homepage/Footer.js
+++ b/src/components/homepage/Footer.js
@@ -28,31 +28,28 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-export function Footer({ links }) {
+export function Footer() {
   const footerItems = [
     {
-        "link": "https://www.redhat.com/en/about/privacy-policy",
-        "label": "Privacy statement"
+      "link": "https://www.redhat.com/en/about/privacy-policy",
+      "label": "Privacy statement"
     },
     {
-        "link": "https://www.redhat.com/en/about/terms-use",
-        "label": "Terms of use"
+      "link": "https://www.redhat.com/en/about/terms-use",
+      "label": "Terms of use"
     },
     {
-        "link": "https://www.redhat.com/en/about/all-policies-guidelines",
-        "label": "Policies and guidelines"
+      "link": "https://www.redhat.com/en/about/all-policies-guidelines",
+      "label": "Policies and guidelines"
     },
     {
-        "link": "https://openinfra.dev/legal/code-of-conduct",
-        "label": "Code of Conduct"
+      "link": "https://openinfra.dev/legal/code-of-conduct",
+      "label": "Code of Conduct"
     }
   ]
-  if (!links) {
-    links = footerItems;
-  }
 
   const { classes } = useStyles();
-  const items = links.map((link) => (
+  const items = footerItems.map((link) => (
     <Anchor
       color="dimmed"
       key={link.label}
@@ -68,7 +65,7 @@ export function Footer({ links }) {
     <div className={classes.footer}>
       <Container className={classes.inner}>
         <a href="https://www.redhat.com/en" target="_blank" rel="noreferrer">
-            <img src={rhlogo} width="100"/>
+          <img src={rhlogo} width="100" />
         </a>
         <Text color="dimmed" size="xs">Operate First is a Red Hat initiative</Text>
         <Group className={classes.links}>{items}</Group>
@@ -78,5 +75,5 @@ export function Footer({ links }) {
 }
 
 Footer.propTypes = {
-    links: PropTypes.array,
+  links: PropTypes.array,
 }

--- a/src/components/homepage/Navbar.js
+++ b/src/components/homepage/Navbar.js
@@ -80,7 +80,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 
-export function Nav({ links }) {
+export function Nav() {
   const [opened, toggleOpened] = useBooleanToggle(false);
   const { classes } = useStyles();
   const navItems = [
@@ -105,11 +105,8 @@ export function Nav({ links }) {
       "label": "Community Cloud"
     }
   ];
-  if (!links) {
-    links = navItems;
-  }
 
-  const items = links.map((link) => (
+  const items = navItems.map((link) => (
     <Link
       key={link.label}
       to={link.link}

--- a/src/pages/docs-training.js
+++ b/src/pages/docs-training.js
@@ -6,49 +6,11 @@ import { Footer } from "../components/homepage/Footer";
 import { DocTrainingContent } from "../components/nav-tabs/DocTraining";
 
 const DocsTrainingPage = () => {
-    const navItems = [
-        {
-            "link": "/about",
-            "label": "Our Purpose"
-        },
-        {
-            "link": "/our-community",
-            "label": "Community"
-        },
-        {
-            "link": "/docs-training",
-            "label": "Docs & Training"
-        },
-        {
-            "link": "/community-cloud",
-            "label": "Op1st Community Cloud"
-        }
-    ]
-
-    const footerItems = [
-        {
-            "link": "https://www.redhat.com/en/about/privacy-policy",
-            "label": "Privacy statement"
-        },
-        {
-            "link": "https://www.redhat.com/en/about/terms-use",
-            "label": "Terms of use"
-        },
-        {
-            "link": "https://www.redhat.com/en/about/all-policies-guidelines",
-            "label": "Policies and guidelines"
-        },
-        {
-            "link": "https://openinfra.dev/legal/code-of-conduct",
-            "label": "Code of Conduct"
-        }
-    ]
-
     return (
         <main>
-            <Nav links={navItems} />
+            <Nav />
             <DocTrainingContent />
-            <Footer links={footerItems} />
+            <Footer />
         </main>
     )
 }

--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -129,9 +129,7 @@ const ActionPage = () => {
 
         <Text pb="xl">
         </Text>
-
       </Container>
-
       <Footer />
     </main>
   )


### PR DESCRIPTION
## Description
This commit removes the manually created navLinks & footerLink objects created in the `docs-training.js` file. Meaning now the same nav-items will appear in each page.

This commit also removes links as props for `Footer.js` and `Navbar.js` since the object is defined in the function/component itself

Misc:
- Fixed some random whitespace