### PR TITLE
Added horizontal margin to blog-post wrapper

### DIFF
--- a/src/components/post.tsx
+++ b/src/components/post.tsx
@@ -12,6 +12,12 @@ import { Layout } from './Layout';
 const useStyles = createStyles((theme) => ({
   wrapper: {
     padding: `${theme.spacing.xl * 2}px ${theme.spacing.xl}px`,
+    marginLeft: '10%',
+    marginRight: '10%',
+    [theme.fn.smallerThan('sm')]: {
+      marginLeft: 0,
+      marginRight: 0,
+    },
   },
 }));
 


### PR DESCRIPTION
## Description
This PR adds horizontal margin to the blog-post wrapper which now makes the articles more readable on larger screens.

The margin looks fine on mobile devices, so the margin is reverted back at a small device breakpoints

## Preview
![image](https://user-images.githubusercontent.com/68972382/181865382-81dac93e-ab85-41c4-a7ed-5a9542b7ca0d.png)
