### PR TITLE
and to & - fitting into the box

### DIFF
--- a/src/components/homepage/About.js
+++ b/src/components/homepage/About.js
@@ -64,7 +64,7 @@ const mockdata = [
   },
   {
     icon: Cloud,
-    title: 'SRE and DevOps',
+    title: 'SRE & DevOps',
     description:
       'Site reliability engineering (SRE) is the evolution of DevOps for operating managed services. Join the movement to learn, capture, and apply SRE best practices in an Open operations environment, and help app developers build operations considerations back into their code.',
   },


### PR DESCRIPTION
The `and` adds too much space and the `s` of `DevOps` reaches over the golden box.
Changing `and` to `&` removes 2 characters, therefore it will fully fit into the box.
![image](https://user-images.githubusercontent.com/89909507/182141245-723d40e9-bd62-4723-a7e1-064d05f68172.png)
