### PR TITLE
website: some cleanups, general fixes and issue related

### DIFF
--- a/src/components/ServiceList.js
+++ b/src/components/ServiceList.js
@@ -10,7 +10,7 @@ const services = [
   {
     title: 'Grafana',
     image: GrafanaLogo,
-    url: 'https://www.operate-first.cloud/apps/content/grafana/README.html',
+    url: 'https://www.operate-first.cloud/apps/content/grafana/docs/README.html#',
     description: 'Dashboard anything. Observe everything.',
   },
   {

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -14,7 +14,7 @@ import {
   SimpleGrid,
   UnstyledButton,
 } from '@mantine/core';
-import { Book, Cloud } from 'tabler-icons-react';
+import { Book, Cloud, ListDetails, LayoutDashboard } from 'tabler-icons-react';
 
 const clusters = [
   {
@@ -46,21 +46,6 @@ const clusters = [
     icon: Cloud,
     color: 'orange',
     url: 'https://console-openshift-console.apps.balrog.aws.operate-first.cloud/',
-  },
-];
-
-const grafanaLinks = [
-  {
-    name: 'smaug',
-    link: 'https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/smaug&var-namespace=All&theme=light&panelId=4',
-  },
-  {
-    name: 'infra',
-    link: 'https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=moc/infra&var-namespace=All&theme=light&panelId=4',
-  },
-  {
-    name: 'balrog',
-    link: 'https://grafana-public.operate-first.cloud/d-solo/opf-overview/workload-overview?orgId=1&var-datasource=default&var-cluster=emea/balrog&var-namespace=All&theme=light&panelId=4',
   },
 ];
 
@@ -119,7 +104,7 @@ const CommunityCloudPage = () => {
     <Layout>
       <Container pb={69}>
         <Title order={2} my="md">
-          Op1st Community Cloud
+          Operate First Community Cloud
         </Title>
         <Text>
           The Operate First Community Cloud is a shared environment for Open
@@ -134,11 +119,9 @@ const CommunityCloudPage = () => {
             <b>Click here to get started as a user and contributor</b>
           </a>
         </Text>
-
         <Title order={2} my="lg">
           Resources
         </Title>
-
         <Group mb={40}>
           <a href="https://www.operate-first.cloud/apps/content/README.html">
             <Button leftIcon={<Book />} color="dark">
@@ -156,25 +139,27 @@ const CommunityCloudPage = () => {
             </Button>
           </a>
         </Group>
-
+        <Group mb={40}>
+          <a href="https://service-catalog.operate-first.cloud/">
+            <Button leftIcon={<LayoutDashboard />} color="dark">
+              Our Services
+            </Button>
+          </a>
+          <a href="https://www.operate-first.cloud/apps/content/README.html">
+            <Button leftIcon={<ListDetails />} color="dark">
+              Environments
+            </Button>
+          </a>
+        </Group>
         <Title order={2} my="md">
           Clusters
         </Title>
-
         <Card withBorder radius="md" className={classes.card}>
           <SimpleGrid cols={3} mt="md">
             {items}
           </SimpleGrid>
         </Card>
-
         <ServicesBoard />
-
-        <Title order={2} my="md">
-          Workloads
-        </Title>
-        <iframe src={grafanaLinks[0].link} className={classes.frame}></iframe>
-        <iframe src={grafanaLinks[1].link} className={classes.frame}></iframe>
-        <iframe src={grafanaLinks[2].link} className={classes.frame}></iframe>
       </Container>
     </Layout>
   );

--- a/src/pages/developer.js
+++ b/src/pages/developer.js
@@ -15,13 +15,14 @@ const DeveloperPage = () => {
         </Text>
         <Text py="sm">
           If you are interested in running your Open Source software in the
-          Op1st community cloud, as a way to gain operational insights to make
-          your software easier to run (operate) and debug in a production cloud,
-          take these steps:
+          Operate First community cloud, as a way to gain operational insights
+          to make your software easier to run (operate) and debug in a
+          production cloud, take these steps:
         </Text>
         <List type="ordered" py="lg" withPadding>
           <List.Item>
-            Open a general Question issue in the Op1st support repo using{' '}
+            Open a general Question issue in the Operate First support repo
+            using{' '}
             <a href="https://github.com/operate-first/support/issues/new?assignees=&labels=question&template=question.md&title=">
               this template
             </a>
@@ -32,25 +33,25 @@ const DeveloperPage = () => {
           <List.Item py="xs">
             You may be asked or wish to already join the{' '}
             <a href="https://lists.operate-first.cloud/archives/list/community@lists.operate-first.cloud/">
-              Op1st community mailing list
+              Operate First community mailing list
             </a>
             , which is used for broader discussion topics and easy community
             transparency.
           </List.Item>
           <List.Item>
             Before and during this process, continue using the “Learning
-            Resources” below for your own education. The Op1st community cloud
-            is a GitOps environment, meaning you will have the capability of
-            initiating your own operation requests using a git workflow. In many
-            cases, initiating via GitOps is the only way to accomplish
+            Resources” below for your own education. The Operate First community
+            cloud is a GitOps environment, meaning you will have the capability
+            of initiating your own operation requests using a git workflow. In
+            many cases, initiating via GitOps is the only way to accomplish
             something.
           </List.Item>
         </List>
         <Text></Text>
         <Text>
           If you have any further questions, you can reach to{' '}
-          <a href="https://www.operate-first.cloud/community-handbook/support/README.md">
-            Op1st community support
+          <a href="https://old.operate-first.cloud/community-handbook/support/README.md">
+            Operate First community support
           </a>{' '}
           for help.
         </Text>
@@ -58,16 +59,17 @@ const DeveloperPage = () => {
           Learning Resources
         </Title>
         <Text py="md">
-          As the Op1st project adds training and other learning resources, those
-          will be linked in here to help Open Source developers find a learning
-          pathway or self-directed learning within these materials.
+          As the Operate First project adds training and other learning
+          resources, those will be linked in here to help Open Source developers
+          find a learning pathway or self-directed learning within these
+          materials.
         </Text>
         <Text>
           The GitOps Reference Documentation is useful for finding the what and
           how of getting operations done in the project. Beginning in January
           2022 the project is rolling out SRE training courses, which will
-          incorporate meaningful examples from the running Op1st community
-          cloud.
+          incorporate meaningful examples from the running Operate First
+          community cloud.
         </Text>
         <Text py="md">
           <b>Source:</b>{' '}

--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -19,13 +19,14 @@ const GettingStartedPage = () => {
         </Title>
         <Text py="sm">
           This page is to help you get started using or contributing to the
-          Operate First (Op1st) project.
+          Operate First (Operate First) project.
         </Text>
         <Text py="sm">
           <b>Users</b> are typically interested in doing work with the tools
-          available in the Op1st community cloud. This page will guide you in
-          understanding what those tools are and how to access them, along with
-          some documentation and pointers to more comprehensive materials.
+          available in the Operate First community cloud. This page will guide
+          you in understanding what those tools are and how to access them,
+          along with some documentation and pointers to more comprehensive
+          materials.
         </Text>
         <Text py="sm">
           <b>Contributors</b> may also be doing work with the tools in the

--- a/src/pages/our-community.js
+++ b/src/pages/our-community.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Button, Container, Text, Title, Center } from '@mantine/core';
+import { Button, Container, Text, Title, Center, Group } from '@mantine/core';
 import { createStyles, SimpleGrid, ThemeIcon, Grid, Col } from '@mantine/core';
 import {
   BuildingCommunity,
   MailFast,
   Speakerphone,
   BrandTwitter,
+  Book,
 } from 'tabler-icons-react';
 
 import { Layout } from '../components/Layout.tsx';
@@ -171,9 +172,24 @@ const CommunityPage = () => {
         </Grid>
       </div>
       <Center pb={40}>
-        <a href="https://www.operate-first.cloud/community/README.html">
-          <Button>Operate First community resources</Button>
-        </a>
+        <Group>
+          <Button
+            leftIcon={<BuildingCommunity />}
+            className={classes.button}
+            component="a"
+            href="https://www.operate-first.cloud/community/README.html"
+          >
+            Operate First community planning repository
+          </Button>
+          <Button
+            leftIcon={<Book />}
+            className={classes.button}
+            component="a"
+            href="https://github.com/operate-first/community-handbook"
+          >
+            Operate First community handbook
+          </Button>
+        </Group>
       </Center>
     </Layout>
   );

--- a/src/pages/srepractices.js
+++ b/src/pages/srepractices.js
@@ -11,11 +11,11 @@ const SREPracticesPage = () => {
           SRE Practices
         </Title>
         <Text>
-          Beginning in January 2022 the Op1st community is releasing early (and
-          often) a growing set of course materials for learning SRE methods and
-          practices. These courses will be tied into the running community
-          cloud, providing a look behind the normal secrecy wall around
-          operations.
+          Beginning in January 2022 the Operate First community is releasing
+          early (and often) a growing set of course materials for learning SRE
+          methods and practices. These courses will be tied into the running
+          community cloud, providing a look behind the normal secrecy wall
+          around operations.
         </Text>
         <Text>
           Our plans for these courses is extensive and will be laid out on these
@@ -28,15 +28,15 @@ const SREPracticesPage = () => {
         </Title>
         <List>
           <List.Item>
-            <a href="https://www.operate-first.cloud/community-handbook/operations-intro.md">
-              SRE pages in the Op1st Community Handbook
+            <a href="https://old.operate-first.cloud/community-handbook/operations-intro.md">
+              SRE pages in the Operate First Community Handbook
             </a>{' '}
-            used by the Op1st Operations SIG.
+            used by the Operate First Operations SIG.
           </List.Item>
           <List.Item py="xs">
             The{' '}
             <a href="https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg/playlists">
-              Op1st video playlists
+              Operate First video playlists
             </a>{' '}
             cover various aspects of how the community cloud works, and other
             aspects of the community.


### PR DESCRIPTION
- general check
- https://github.com/operate-first/operate-first.github.io/issues/76
- https://github.com/operate-first/support/issues/622

replaced op1st with Operate First

fixed community-handbook links to old.operate-.

added link our community

renamed button to O.F. community planning repository

removed Grafana widgets

remove service list grafana, add links to it
https://github.com/operate-first/support/issues/622