### PR TITLE
Removed Morty and Rick clusters from community cloud page

### DIFF
--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -30,18 +30,6 @@ const clusters = [
     url: 'http://console-openshift-console.apps.smaug.na.operate-first.cloud/',
   },
   {
-    title: 'Morty',
-    icon: Cloud,
-    color: 'blue',
-    url: 'https://console-openshift-console.apps.morty.emea.operate-first.cloud/',
-  },
-  {
-    title: 'Rick',
-    icon: Cloud,
-    color: 'blue',
-    url: 'https://console-openshift-console.apps.rick.emea.operate-first.cloud/',
-  },
-  {
     title: 'Balrog',
     icon: Cloud,
     color: 'orange',

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -29,12 +29,6 @@ const clusters = [
     color: 'red',
     url: 'http://console-openshift-console.apps.smaug.na.operate-first.cloud/',
   },
-  {
-    title: 'Balrog',
-    icon: Cloud,
-    color: 'orange',
-    url: 'https://console-openshift-console.apps.balrog.aws.operate-first.cloud/',
-  },
 ];
 
 const useStyles = createStyles((theme) => ({


### PR DESCRIPTION
These clusters are now defunct and should probably not be on the community cloud page.
@dystewart 